### PR TITLE
Loads datamapper_setup in order for it to be recognised in Pry

### DIFF
--- a/ruby/server.rb
+++ b/ruby/server.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'data_mapper'
+load 'datamapper_setup.rb'
 
 class Dog
   include DataMapper::Resource


### PR DESCRIPTION
Heya,

I have been having a go with Data mapper and Sinatra for the last day or so. I tried using Pry to add some more dogs into the Dog class example within the mind-the-code app and it kept error-ing. It seems to work if I load the datamapper_setup file into server.rb file so I made a PR.
